### PR TITLE
Adding error message from pipelinerun on failure

### DIFF
--- a/config/task-monitor-result.yaml
+++ b/config/task-monitor-result.yaml
@@ -12,6 +12,9 @@ spec:
       - name: pipelinerun
         description: The name of the pipelinerun to be monitored
         default: default pipelinerun
+      - name: pipelinerunnamespace
+        description: The namespace of the pipelinerun to be monitored
+        default: target
       - name: commentsuccess
         description: The text of the success comment
         default: default success at task
@@ -33,9 +36,7 @@ spec:
       - name: COMMENT_FAILURE
         value: ${inputs.params.commentfailure}
       - name: NAMESPACE
-        valueFrom:
-          fieldRef:
-            fieldPath: metadata.namespace
+        value: ${inputs.params.pipelinerunnamespace}
     command: ["/bin/bash"]
     args:
     - -ce
@@ -55,6 +56,10 @@ spec:
               comment = "$COMMENT_SUCCESS"
               break
           if output["status"]["conditions"][0]["status"] == u'False' and output["status"]["conditions"][0]["type"] == u'Succeeded':
+              for y in output["status"]["taskRuns"]:
+                  if output["status"]["taskRuns"][y]["status"]["conditions"][0]["status"] == u'False' and \
+                  output["status"]["taskRuns"][y]["status"]["conditions"][0]["type"] == u'Succeeded': 
+                      comment = comment + ": " + output["status"]["taskRuns"][y]["status"]["conditions"][0]["message"]
               break
       with open("/workspace/pull-request/pr.json", 'r') as pr_file:
           data = json.load(pr_file)


### PR DESCRIPTION
1. The error message of the failing task in the pipelinerun is added to the comment message provided as the parameter in the pipelinerun when the pipelinerun fails.  Here is an example of the comment.

> ERROR: knative-demo-test-1564427038: "step-git-source-knative-demo-test-git-source-1564427038-lpk7h" exited with code 1 (image: "docker-pullable://akihikokuroda/git-init-4874978a9786b6625dd8b6ef2a21aa70@sha256:0b05b00fe22441b065a1a6fb4cc733d0e65a2cc93196cce224d36120944c03e8"); for logs run: kubectl -n tekton-pipelines logs knative-demo-test-1564427038-build-simple-7b88t-pod-e8600d -c step-git-source-knative-demo-test-git-source-1564427038-lpk7h

2. The namespace for the monitored pipelinerun is passed as a parameter.