### PR TITLE
Fix simple-pipeline param name mismatch

### DIFF
--- a/config/pipeline.yaml
+++ b/config/pipeline.yaml
@@ -7,7 +7,7 @@ spec:
   - name: event-headers
     type: string
     description: "The event headers"
-  resources: 
+  resources:
   - name: git-source
     type: git
   - name: docker-image
@@ -27,14 +27,14 @@ spec:
     conditions:
     - conditionRef: deployment-condition
       params:
-      - name: event
+      - name: event-headers
         value: $(params.event-headers)
     runAfter: [build-simple]
-    taskRef: 
+    taskRef:
       name: deploy-simple-kubectl-task
-    resources: 
+    resources:
       inputs:
       - name: git-source
-        resource: git-source 
+        resource: git-source
       - name: image-out
         resource: docker-image


### PR DESCRIPTION
`simple-pipeline` was passing param `event`, while condition `deployment-condition` was expecting param `event-headers`.