### PR TITLE
Declare all TriggerTemplate params in the spec

### DIFF
--- a/triggers-resources/config/buildah/buildah-template.yaml
+++ b/triggers-resources/config/buildah/buildah-template.yaml
@@ -5,6 +5,29 @@ kind: TriggerTemplate
 metadata:
   name: buildah-pipeline-template
 spec:
+  params:
+  - name: gitrevision
+    description: The revision of your Git repository
+  - name: gitrepositoryurl
+    description: The url of your Git repository
+  - name: webhooks-tekton-git-server
+    description: The server name in the Git url
+  - name: webhooks-tekton-git-org
+    description: The org name in the Git url
+  - name: webhooks-tekton-git-repo
+    description: The repository name in the Git url
+  - name: webhooks-tekton-git-branch
+    description: The branch for the Git repository
+  - name: event-type
+    description: The Git event type
+  - name: webhooks-tekton-docker-registry
+    description: The image registry
+  - name: docker-tag
+    description: The image tag
+  - name: webhooks-tekton-service-account
+    description: The ServiceAccount that the PipelineRun will execute under
+  - name: webhooks-tekton-target-namespace
+    description: The namespace in which to create this TriggerTemplate's resources
   resourcetemplates:
   - apiVersion: tekton.dev/v1alpha1
     kind: PipelineResource
@@ -50,7 +73,7 @@ spec:
         resourceRef:
           name: git-source-$(uid)
       - name: docker-image
-        resourceRef: 
+        resourceRef:
           name: docker-image-$(uid)
 
 

--- a/triggers-resources/config/simple-pipeline/simple-pipeline-template.yaml
+++ b/triggers-resources/config/simple-pipeline/simple-pipeline-template.yaml
@@ -6,6 +6,29 @@ kind: TriggerTemplate
 metadata:
   name: simple-pipeline-template
 spec:
+  params:
+  - name: gitrevision
+    description: The revision of your Git repository
+  - name: gitrepositoryurl
+    description: The url of your Git repository
+  - name: webhooks-tekton-git-server
+    description: The server name in the Git url
+  - name: webhooks-tekton-git-org
+    description: The org name in the Git url
+  - name: webhooks-tekton-git-repo
+    description: The repository name in the Git url
+  - name: webhooks-tekton-git-branch
+    description: The branch for the Git repository
+  - name: event-type
+    description: The Git event type
+  - name: webhooks-tekton-docker-registry
+    description: The image registry
+  - name: docker-tag
+    description: The image tag
+  - name: webhooks-tekton-service-account
+    description: The ServiceAccount that the PipelineRun will execute under
+  - name: webhooks-tekton-target-namespace
+    description: The namespace in which to create this TriggerTemplate's resources
   resourcetemplates:
   - apiVersion: tekton.dev/v1alpha1
     kind: PipelineResource
@@ -40,7 +63,7 @@ spec:
         webhooks.tekton.dev/gitRepo: $(params.webhooks-tekton-git-repo)
         webhooks.tekton.dev/gitBranch: $(params.webhooks-tekton-git-branch)
     spec:
-      serviceAccount: $(params.webhooks-tekton-service-account)
+      serviceAccountName: $(params.webhooks-tekton-service-account)
       pipelineRef:
         name: simple-pipeline
       params:
@@ -51,7 +74,7 @@ spec:
         resourceRef:
           name: git-source-$(uid)
       - name: docker-image
-        resourceRef: 
+        resourceRef:
           name: docker-image-$(uid)
 
 


### PR DESCRIPTION
This PR fixes issue https://github.com/tektoncd/experimental/issues/426.

If we want, we can add `default` values to any of the parameters. However, I haven't used any `default` values in this PR.

Triggers PR https://github.com/tektoncd/triggers/pull/288 added validation that all params in a TriggerTemplate are declared before they are used.